### PR TITLE
Enable support for SonarQube 4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
   <properties>
     <license.owner>Alexandre Victoor</license.owner>
-    <sonar.buildVersion>3.7</sonar.buildVersion>
+    <sonar.buildVersion>4.2</sonar.buildVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <jdk.min.version>1.5</jdk.min.version>
     <junit.version>4.10</junit.version>


### PR DESCRIPTION
The problem was that `sonar-pitest` would use the `3.7` API, and when running on `4.2`, the following error message would be received:

```
Not supported since v4.2. See http://docs.codehaus.org/display/SONAR/API+Changes
```

Basically, `org.sonar.api.resources.JavaFile` were deprecated.

Also, I guess, http://docs.sonarqube.org/display/SONAR/Plugin+version+matrix should be updated.
