### PR TITLE
Fix native2ascii maven plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,9 @@
 							<encoding>UTF8</encoding>
 							<src>${basedir}/src/main/resources</src>
 							<dest>${project.build.outputDirectory}</dest>
-							<includes>**/*.properties</includes>
+							<includes>
+								<include>**/*.properties</include>
+							</includes>
 						</configuration>
 					</execution>
 				</executions>


### PR DESCRIPTION
Hello,

A small PR fixing your maven configuration, as it seems wrong to me.

I have been trying to build your project (coming from [version 0.8 RFF thread in SonarQube mailing list](https://groups.google.com/d/topic/sonarqube/1rPF7I8uCj0/discussion)), and I was unable to do so locally.

I'm using maven 3.2.5, running with Java version 1.8.0_91 (Oracle).
When executing `mvn clean install`, I'm getting the following error:
```
[ERROR] Failed to execute goal org.codehaus.mojo:native2ascii-maven-plugin:1.0-beta-1:native2ascii (default) on project sonar-pitest-plugin: Unable to parse configuration of mojo org.codehaus.mojo:native2ascii-maven-plugin:1.0-beta-1:native2ascii for parameter includes: Cannot assign configuration entry 'includes' with value '**/*.properties' of type java.lang.String to property of type java.lang.String[] -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.codehaus.mojo:native2ascii-maven-plugin:1.0-beta-1:native2ascii (default) on project sonar-pitest-plugin: Unable to parse configuration of mojo org.codehaus.mojo:native2ascii-maven-plugin:1.0-beta-1:native2ascii for parameter includes: Cannot assign configuration entry 'includes' with value '**/*.properties' of type java.lang.String to property of type java.lang.String[]
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:220)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:120)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:355)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:155)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:584)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:216)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:160)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.PluginConfigurationException: Unable to parse configuration of mojo org.codehaus.mojo:native2ascii-maven-plugin:1.0-beta-1:native2ascii for parameter includes: Cannot assign configuration entry 'includes' with value '**/*.properties' of type java.lang.String to property of type java.lang.String[]
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.populatePluginFields(DefaultMavenPluginManager.java:607)
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.getConfiguredMojo(DefaultMavenPluginManager.java:539)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:119)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	... 19 more
Caused by: org.codehaus.plexus.component.configurator.ComponentConfigurationException: Cannot assign configuration entry 'includes' with value '**/*.properties' of type java.lang.String to property of type java.lang.String[]
	at org.codehaus.plexus.component.configurator.converters.AbstractConfigurationConverter.failIfNotTypeCompatible(AbstractConfigurationConverter.java:100)
	at org.codehaus.plexus.component.configurator.converters.composite.ArrayConverter.fromConfiguration(ArrayConverter.java:65)
	at org.eclipse.sisu.plexus.CompositeBeanHelper.convertProperty(CompositeBeanHelper.java:273)
	at org.eclipse.sisu.plexus.CompositeBeanHelper.setProperty(CompositeBeanHelper.java:210)
	at org.codehaus.plexus.component.configurator.converters.composite.ObjectWithFieldsConverter.processConfiguration(ObjectWithFieldsConverter.java:101)
	at org.codehaus.plexus.component.configurator.BasicComponentConfigurator.configureComponent(BasicComponentConfigurator.java:34)
	at org.apache.maven.plugin.internal.DefaultMavenPluginManager.populatePluginFields(DefaultMavenPluginManager.java:577)
	... 22 more
```

I tried running it on various other machines, with same results. According to this SOF question: https://stackoverflow.com/questions/20735122/learning-maven-unable-to-parse-configuration-for-jar-plugin
It came to me that it could be caused by a misconfiguration of the native2ascii plugin.

The build has been passing correctly again once replacing locally:
```
<includes>**/*.properties</includes>
```
by
```
<includes>
    <include>**/*.properties</include>
</includes>
```

